### PR TITLE
Add new flag `--first-version` to let the user define the first version to use if no previous version tags exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,8 @@ verscout next
 For verscout to calculate the next version,
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) need to exist since the latest version tag.
 
-In the default configuration, using `fix:` will cause a `PATCH` bump,
-using `feat:` will cause a `MINOR` bump,
-and using `BREAKING CHANGE:` in the commit message body will cause a `MAJOR` bump.
+Using the default configuration, `fix:` will cause a `PATCH` bump, `feat:` will cause a `MINOR` bump,
+and `BREAKING CHANGE:` in the commit message body will cause a `MAJOR` bump.
 This behavior can be [configured](#custom-bump-configuration)
 
 ### Configure `verscout`
@@ -176,12 +175,12 @@ You can change this behavior with the `--exit-code` flag
 verscout next --exit-code 4
 ```
 
-### Limitations
+## Limitations
 
 - The format of the version tags is currently not configurable
 - Bumping any prerelease or release candidate versions is not supported
 
-## Planned Features and Limitations
+## Planned Features
 
 Please check the open [GitHub Issues](https://github.com/erNail/homebrew-tap/issues)
 to get an overview of the planned features.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ verscout next --exit-code 4
 
 ## Planned Features
 
-Please check the open [GitHub Issues](https://github.com/erNail/homebrew-tap/issues)
+Please check the open [GitHub Issues](https://github.com/erNail/verscout/issues)
 to get an overview of the planned features.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Using the default configuration, `fix:` will cause a `PATCH` bump, `feat:` will 
 and `BREAKING CHANGE:` in the commit message body will cause a `MAJOR` bump.
 This behavior can be [configured](#custom-bump-configuration)
 
+If no version tags exist, the first version will be `1.0.0`
+This behavior can also be [configured](#custom-first-version)
+
 ### Configure `verscout`
 
 To get a complete list of the configuration options, please use the `--help` or `-h` flag.
@@ -159,6 +162,19 @@ You can also specify a different file path:
 ```shell
 verscout next --config path/to/your/config.yaml
 ```
+
+##### Custom First Version
+
+By default, if no version tags exist, the first version will be `1.0.0`.
+You can configure this behavior:
+
+```shell
+verscout next --first-version 0.1.0
+```
+
+Be aware that this will have no effect on the keywords and the type of bump they cause.
+For example, if you want the keyword `BREAKING CHANGE:` to not cause a bump from `0.1.0` to `1.0.0`, you should
+use a [custom bump configuration](#custom-bump-configuration).
 
 ##### Exit Code if no next version is found
 

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHandleNextCommand_NoExistingTags(t *testing.T) {
+func TestHandleNextCommand_NoExistingTags_DefaultFirstVersion(t *testing.T) {
 	t.Parallel()
 
 	repo, err := gitutils.CreateTestRepo()
@@ -24,10 +24,42 @@ func TestHandleNextCommand_NoExistingTags(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.0.0\n", output.String())
+}
+
+func TestHandleNextCommand_NoExistingTags_CustomFirstVersion(t *testing.T) {
+	t.Parallel()
+
+	repo, err := gitutils.CreateTestRepo()
+	require.NoError(t, err)
+	_, err = gitutils.CreateTestCommit(repo, "First commit", "README.md", "Hello, World!", time.Now())
+	require.NoError(t, err)
+
+	repoDirectoryPath := "."
+
+	var output bytes.Buffer
+
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"0.1.0",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "0.1.0\n", output.String())
 }
 
 func TestHandleNextCommand_ValidExistingTag(t *testing.T) {
@@ -52,7 +84,14 @@ func TestHandleNextCommand_ValidExistingTag(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.0.1\n", output.String())
@@ -80,7 +119,14 @@ func TestHandleNextCommand_ValidExistingTagWithVPrefix(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.0.1\n", output.String())
@@ -108,7 +154,14 @@ func TestHandleNextCommand_InvalidExistingTag(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.0.0\n", output.String())
@@ -136,7 +189,14 @@ func TestHandleNextCommand_MajorBump(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "2.0.0\n", output.String())
@@ -164,7 +224,14 @@ func TestHandleNextCommand_MinorBump(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.1.0\n", output.String())
@@ -192,7 +259,14 @@ func TestHandleNextCommand_NoBumpChore(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Empty(t, output.String())
@@ -212,7 +286,14 @@ func TestHandleNextCommand_NoBumpNoAdditionalCommits(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Empty(t, output.String())
@@ -240,7 +321,14 @@ func TestHandleNextCommand_AnnotatedExistingTag(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 0, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		0,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.0.1\n", output.String())
@@ -260,7 +348,14 @@ func TestHandleNextCommand_NoNextVersionExitCode_NoNewCommits(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 2, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		2,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.Error(t, err)
 
 	var exitErr *ExitError
@@ -291,7 +386,14 @@ func TestHandleNextCommand_NoNextVersionExitCode_NoBumpCommits(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 2, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		2,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.Error(t, err)
 
 	var exitErr *ExitError
@@ -322,7 +424,14 @@ func TestHandleNextCommand_NoNextVersionExitCode_FixCommit(t *testing.T) {
 
 	var output bytes.Buffer
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoDirectoryPath, 2, ".verscout-config.yaml")
+	err = HandleNextCommand(
+		&output,
+		&gitutils.MockGit{Repo: repo},
+		&repoDirectoryPath,
+		2,
+		".verscout-config.yaml",
+		"1.0.0",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.0.1\n", output.String())
@@ -374,7 +483,7 @@ bumps:
 
 	repoPath := "."
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoPath, 0, configPath)
+	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoPath, 0, configPath, "1.0.0")
 	require.NoError(t, err)
 	assert.Equal(t, "2.0.0\n", output.String())
 }
@@ -402,7 +511,7 @@ func TestHandleNextCommand_InvalidConfig(t *testing.T) {
 
 	repoPath := "."
 
-	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoPath, 0, configPath)
+	err = HandleNextCommand(&output, &gitutils.MockGit{Repo: repo}, &repoPath, 0, configPath, "1.0.0")
 	require.NoError(t, err)
 	assert.Equal(t, "1.0.1\n", output.String())
 }


### PR DESCRIPTION
Resolves #29 